### PR TITLE
fix: simplify vercel.json rewrite — remove broken negative lookahead …

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
…regex

Vercel's path-to-regexp does not support negative lookaheads. The old pattern /((?!api/).*)  was catching /api/notion/* requests and returning index.html instead of routing to the serverless function.

Vercel auto-routes api/ directory functions before applying rewrites, so the plain /(.*) → /index.html rewrite is correct and sufficient.