### PR TITLE
fix: switch vercel.json to routes with handle:filesystem

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
rewrites alone don't guarantee function routing takes priority in Vercel's Vite framework preset. routes + handle:filesystem explicitly checkpoints static files and api/ functions first, then falls through to the SPA route — the canonical fix for API + SPA coexistence.

Before: POST /api/notion/* → caught by /(.*) rewrite → index.html → 405
After:  POST /api/notion/* → handle:filesystem → serverless function → Notion API