### PR TITLE
fix: convert Notion proxy to Vercel Edge Function

### DIFF
--- a/api/notion/[...path].ts
+++ b/api/notion/[...path].ts
@@ -1,19 +1,24 @@
-import type { VercelRequest, VercelResponse } from '@vercel/node';
+export const config = { runtime: 'edge' };
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const pathSegments = (req.query.path as string[]) ?? [];
-  const notionPath = pathSegments.join('/');
+export default async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+
+  // Strip /api/notion prefix to get the Notion API path
+  const notionPath = url.pathname.replace(/^\/api\/notion\/?/, '');
 
   const notionRes = await fetch(`https://api.notion.com/v1/${notionPath}`, {
-    method: req.method,
+    method: request.method,
     headers: {
       Authorization: `Bearer ${process.env.NOTION_API_KEY}`,
       'Notion-Version': '2022-06-28',
       'Content-Type': 'application/json',
     },
-    body: req.method !== 'GET' ? JSON.stringify(req.body) : undefined,
+    body: request.method !== 'GET' ? request.body : undefined,
   });
 
-  const data = await notionRes.json();
-  res.status(notionRes.status).json(data);
+  const text = await notionRes.text();
+  return new Response(text, {
+    status: notionRes.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }


### PR DESCRIPTION
The Node.js serverless function was silently not being detected/deployed on Vercel Hobby (Routes table showed empty, 0 invocations).

Edge Functions use the standard Web Request/Response API, are available on all Vercel plans, and are reliably picked up by the build system. No @vercel/node dependency needed — native fetch handles the proxy.